### PR TITLE
Add interactive Interview-Express portfolio game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# TheGame
+# Rolands Interview-Express
+
+Eine spielerische „Über mich“-Webseite für Bewerbungen. Recruiter fahren durch vier kompakte Stationen, schalten Mini-Interaktionen frei und landen schließlich beim Kontakt-CTA.
+
+## Features
+- Lineare Reise mit Fortschrittsanzeige durch Story-, Skill-, Projekt- und Soft-Skill-Stationen
+- Mikrointeraktionen pro Station (Entscheidung, Quiz, Ticket-Scan, Crew-Karten)
+- Easter Egg über die Hupe im Footer
+- Komplett umgesetzt mit purem PHP, Vanilla JavaScript und CSS
+
+## Lokale Entwicklung
+```bash
+php -S localhost:8000
+```
+
+Danach im Browser `http://localhost:8000/index.php` öffnen.
+
+## Struktur
+- `index.php` – Generiert Inhalte und Struktur des Spiels
+- `assets/style.css` – Stylesheet für Layout, Farben und Animationen
+- `assets/script.js` – Spiel-Logik und Micro-Interactions
+
+Viel Spaß bei der Fahrt! 🚂

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,258 @@
+const stations = Array.from(document.querySelectorAll('.station'));
+const progressBar = document.querySelector('.progress__bar span');
+const progressLabel = document.querySelector('.progress__label');
+const mainElement = document.querySelector('main');
+const heroStart = document.querySelector('[data-action="start"]');
+const finalSection = document.getElementById('final-stop');
+const replayButton = finalSection?.querySelector('[data-action="replay"]');
+const hornButton = document.querySelector('[data-horn]');
+const hornSecret = document.querySelector('.horn-secret');
+
+let currentIndex = -1;
+let hornTaps = 0;
+let hornTimeout;
+
+const stationState = new Map();
+stations.forEach((station) => stationState.set(station.id, { completed: false }));
+
+function updateProgress() {
+  const total = stations.length;
+  const current = Math.min(Math.max(currentIndex + 1, 0), total);
+  const percent = total === 0 ? 0 : Math.min((current / total) * 100, 100);
+  if (progressBar) progressBar.style.width = `${percent}%`;
+  if (progressLabel) progressLabel.textContent = `Station ${current} von ${total}`;
+}
+
+function showStation(index) {
+  stations.forEach((station, i) => {
+    station.hidden = i !== index;
+  });
+  if (finalSection) finalSection.hidden = true;
+  currentIndex = index;
+  updateProgress();
+}
+
+function showFinal() {
+  stations.forEach((station) => (station.hidden = true));
+  if (finalSection) finalSection.hidden = false;
+  currentIndex = stations.length;
+  updateProgress();
+}
+
+function enableNext(station) {
+  const nextButton = station.querySelector('[data-action="next"]');
+  if (nextButton) nextButton.disabled = false;
+  if (!stationState.has(station.id)) {
+    stationState.set(station.id, { completed: true });
+  } else {
+    stationState.get(station.id).completed = true;
+  }
+}
+
+function handleNavigation(event) {
+  const button = event.target.closest('[data-action]');
+  if (!button) return;
+
+  const action = button.dataset.action;
+  if (action === 'start') {
+    showStation(0);
+    if (mainElement) {
+      window.scrollTo({ top: mainElement.offsetTop, behavior: 'smooth' });
+    }
+  }
+
+  if (currentIndex < 0) return;
+  const currentStation = stations[currentIndex];
+
+  switch (action) {
+    case 'next': {
+      const state = stationState.get(currentStation.id);
+      if (!state || !state.completed) return;
+      if (currentIndex === stations.length - 1) {
+        showFinal();
+        if (mainElement) {
+          window.scrollTo({ top: mainElement.offsetTop, behavior: 'smooth' });
+        }
+      } else {
+        showStation(currentIndex + 1);
+      }
+      break;
+    }
+    case 'prev': {
+      if (currentIndex === 0) {
+        currentStation.hidden = true;
+        currentIndex = -1;
+        updateProgress();
+        break;
+      }
+      if (currentIndex > 0) {
+        showStation(currentIndex - 1);
+      }
+      break;
+    }
+    case 'replay': {
+      showStation(0);
+      if (mainElement) {
+        window.scrollTo({ top: mainElement.offsetTop, behavior: 'smooth' });
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+document.addEventListener('click', handleNavigation);
+
+function initStoryStation(station) {
+  const choices = station.querySelectorAll('[data-story-choice]');
+  const result = station.querySelector('[data-result="story"]');
+  const achievement = station.querySelector('[data-achievement]');
+
+  choices.forEach((choice) => {
+    choice.addEventListener('click', () => {
+      const key = choice.dataset.storyChoice;
+      const data = {
+        cms: 'CMS-Relaunch: Ich habe Content-Modelle entschlackt und Versionierung eingeführt.',
+        intranet: 'Kommunikations-App: Fokus auf Moderationsrechte und mobile Performance.'
+      };
+      if (result) {
+        result.textContent = data[key];
+      }
+      if (achievement) {
+        achievement.textContent = 'Recruiter-Notiz: Ich liefere auch unter Zeitdruck planbar aus.';
+      }
+      choices.forEach((btn) => btn.classList.toggle('is-active', btn === choice));
+      enableNext(station);
+    });
+  });
+}
+
+function initSkillStation(station) {
+  const options = station.querySelectorAll('[data-correct]');
+  const result = station.querySelector('[data-result="skills"]');
+
+  options.forEach((option) => {
+    option.addEventListener('click', () => {
+      const isCorrect = option.dataset.correct === 'true';
+      const proof = option.dataset.proof;
+      options.forEach((btn) => btn.classList.remove('is-active', 'is-wrong'));
+      option.classList.add(isCorrect ? 'is-active' : 'is-wrong');
+      if (result) {
+        result.textContent = proof;
+        result.style.color = isCorrect ? 'var(--secondary)' : '#f87171';
+      }
+      if (isCorrect) enableNext(station);
+    });
+  });
+}
+
+function initProjectsStation(station) {
+  const projects = station.querySelectorAll('[data-project]');
+  const result = station.querySelector('[data-result="projects"]');
+  const opened = new Set();
+
+  projects.forEach((project) => {
+    const trigger = project.querySelector('[data-project-open]');
+    const details = project.querySelector('.project-details');
+    if (!trigger || !details) return;
+    trigger.addEventListener('click', () => {
+      const hidden = details.hasAttribute('hidden');
+      details.toggleAttribute('hidden', !hidden);
+      project.classList.toggle('is-active', hidden);
+      if (hidden) {
+        opened.add(project);
+      }
+      if (result) {
+        result.textContent = `${opened.size} Ticket(s) geprüft – gerne zeige ich mehr im Call.`;
+      }
+      if (opened.size >= 2) {
+        enableNext(station);
+      }
+    });
+  });
+}
+
+function initPersonalityStation(station) {
+  const traits = station.querySelectorAll('[data-trait]');
+  const result = station.querySelector('[data-result="personality"]');
+  const opened = new Set();
+
+  traits.forEach((trait) => {
+    trait.addEventListener('click', () => {
+      const text = trait.querySelector('.trait__text');
+      const hidden = text.hasAttribute('hidden');
+      text.toggleAttribute('hidden', !hidden);
+      trait.classList.toggle('is-active', hidden);
+      if (hidden) opened.add(trait);
+      if (result) {
+        result.textContent = `${opened.size}/3 Crew-Karten aufgedeckt`;
+      }
+      if (opened.size === traits.length) {
+        result.textContent = 'Crew komplett – lass uns zusammen den nächsten Sprint planen!';
+        enableNext(station);
+      }
+    });
+  });
+}
+
+stations.forEach((station) => {
+  if (station.id.includes('story')) initStoryStation(station);
+  if (station.id.includes('skills')) initSkillStation(station);
+  if (station.id.includes('projects')) initProjectsStation(station);
+  if (station.id.includes('personality')) initPersonalityStation(station);
+});
+
+if (heroStart) {
+  heroStart.addEventListener('click', () => {
+    showStation(0);
+  });
+}
+
+if (replayButton) {
+  replayButton.addEventListener('click', () => {
+    stations.forEach((station) => {
+      stationState.set(station.id, { completed: false });
+      const nextButton = station.querySelector('[data-action="next"]');
+      if (nextButton) nextButton.disabled = true;
+      station
+        .querySelectorAll('.is-active, .is-wrong')
+        .forEach((el) => el.classList.remove('is-active', 'is-wrong'));
+      station.querySelectorAll('[data-result]').forEach((res) => {
+        res.textContent = '';
+        res.removeAttribute('style');
+      });
+      station.querySelectorAll('.project-details').forEach((details) => details.setAttribute('hidden', ''));
+      station.querySelectorAll('.trait__text').forEach((text) => text.setAttribute('hidden', ''));
+    });
+    hornTaps = 0;
+    if (hornSecret) {
+      hornSecret.textContent = '';
+    }
+    showStation(0);
+  });
+}
+
+if (hornButton) {
+  hornButton.addEventListener('click', () => {
+    hornTaps += 1;
+    clearTimeout(hornTimeout);
+    hornTimeout = setTimeout(() => {
+      hornTaps = 0;
+      if (hornSecret) {
+        hornSecret.textContent = '';
+      }
+    }, 1200);
+
+    if (!hornSecret) return;
+
+    if (hornTaps >= 3) {
+      hornSecret.textContent = 'Nightshift-Snack: Franzbrötchen mit kaltem Brew-Kaffee.';
+      hornTaps = 0;
+    } else {
+      hornSecret.textContent = `Hupe ${hornTaps}/3`;
+    }
+  });
+}
+
+updateProgress();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,319 @@
+:root {
+    --bg: #10131a;
+    --card-bg: rgba(20, 26, 36, 0.85);
+    --primary: #4fd1c5;
+    --secondary: #f6ad55;
+    --text: #f8fafc;
+    --muted: #94a3b8;
+    --border: rgba(255, 255, 255, 0.08);
+    --radius: 16px;
+    --transition: 220ms ease;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: radial-gradient(circle at top, #1e293b, var(--bg));
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+h1, h2, h3, h4 {
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+}
+
+p {
+    margin: 0 0 1rem;
+    line-height: 1.5;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+main {
+    flex: 1;
+    padding: 2rem clamp(1rem, 4vw, 4rem) 4rem;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    align-items: center;
+    padding: 3rem clamp(1rem, 4vw, 4rem) 2rem;
+}
+
+.hero__tagline {
+    font-size: 1.1rem;
+    color: var(--secondary);
+}
+
+.hero__train {
+    width: 100%;
+    height: 220px;
+    background: linear-gradient(135deg, rgba(79, 209, 197, 0.2), rgba(246, 173, 85, 0.1));
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.5);
+    position: relative;
+    overflow: hidden;
+}
+
+.hero__train::before,
+.hero__train::after {
+    content: '';
+    position: absolute;
+    inset: 20%;
+    border-radius: var(--radius);
+    border: 2px dashed rgba(79, 209, 197, 0.3);
+    animation: pulse 6s infinite;
+}
+
+.hero__train::after {
+    inset: 30%;
+    animation-delay: 1.5s;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); opacity: 1; }
+    100% { transform: scale(1.2); opacity: 0; }
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1.4rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text);
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+    font-weight: 600;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 30px rgba(79, 209, 197, 0.2);
+}
+
+.btn--primary {
+    background: var(--primary);
+    color: #02131a;
+}
+
+.btn--secondary {
+    background: rgba(246, 173, 85, 0.2);
+    border-color: rgba(246, 173, 85, 0.3);
+}
+
+.btn--ghost {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+.progress {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 2rem;
+}
+
+.progress__bar {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    overflow: hidden;
+}
+
+.progress__bar span {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, var(--primary), var(--secondary));
+    transition: width 320ms ease;
+}
+
+.progress__label {
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.station {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 20px 60px rgba(8, 15, 30, 0.6);
+}
+
+.station header p {
+    color: var(--muted);
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.2rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius);
+    transition: transform var(--transition), background var(--transition), border-color var(--transition);
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+}
+
+.card:hover {
+    transform: translateY(-3px);
+    background: rgba(79, 209, 197, 0.1);
+    border-color: rgba(79, 209, 197, 0.4);
+}
+
+.card.is-active {
+    background: rgba(79, 209, 197, 0.18);
+    border-color: rgba(79, 209, 197, 0.6);
+    box-shadow: 0 12px 30px rgba(79, 209, 197, 0.25);
+}
+
+.card.is-wrong {
+    background: rgba(248, 113, 113, 0.15);
+    border-color: rgba(248, 113, 113, 0.6);
+}
+
+.card--trait .trait__text {
+    font-weight: 400;
+    color: var(--muted);
+}
+
+.card--choice span,
+.card--option,
+.card--trait span {
+    font-weight: 600;
+}
+
+.choices,
+.quiz__options,
+.traits {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin-bottom: 1.5rem;
+}
+
+.quiz__question {
+    font-size: 1.1rem;
+    margin-bottom: 1rem;
+}
+
+.project-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin-bottom: 1.5rem;
+}
+
+.project-details {
+    display: grid;
+    gap: 0.3rem;
+    font-size: 0.95rem;
+    color: var(--muted);
+}
+
+.project-details dt {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.station__result {
+    min-height: 1.5rem;
+    color: var(--secondary);
+    font-weight: 600;
+}
+
+.station__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.achievement {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.final {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 2rem;
+    text-align: center;
+    box-shadow: 0 20px 60px rgba(8, 15, 30, 0.6);
+}
+
+.final__actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin: 1.5rem 0;
+    flex-wrap: wrap;
+}
+
+.final__surprise {
+    color: var(--secondary);
+    font-style: italic;
+}
+
+.footer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(2, 6, 14, 0.9);
+}
+
+.horn-secret {
+    min-width: 200px;
+    text-align: center;
+    color: var(--secondary);
+}
+
+@media (max-width: 720px) {
+    main {
+        padding-top: 1rem;
+    }
+
+    .station {
+        padding: 1.5rem;
+    }
+
+    .hero {
+        padding-bottom: 1rem;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,217 @@
+<?php
+$profile = [
+    'name' => 'Roland Burmberger',
+    'role' => 'Fullstack Webentwickler',
+    'tagline' => 'Ich baue performante Kommunikationslösungen mit purem PHP und Vanilla JS.',
+    'intro' => 'Steig ein in den Interview-Express und lerne meinen Werdegang als spielbare Kurzreise kennen.'
+];
+
+$stations = [
+    [
+        'id' => 'story',
+        'title' => 'Station 1 · Story',
+        'subtitle' => 'Wähle meine erste große Herausforderung',
+        'content' => [
+            'cms' => [
+                'label' => 'CMS-Relaunch für lokale Handwerkskammer',
+                'description' => 'Mit 20 habe ich ein bestehendes CMS komplett neu strukturiert, damit 30 Redakteure wieder effizient arbeiten konnten.'
+            ],
+            'intranet' => [
+                'label' => 'Kommunikations-App für 150 Mitarbeiter',
+                'description' => 'Ich entwickelte in drei Wochen eine Messenger- und Newsplattform mit granularen Rollenrechten.'
+            ]
+        ],
+        'achievement' => 'Erfolg: Rollout innerhalb von 6 Wochen, Support inklusive.'
+    ],
+    [
+        'id' => 'skills',
+        'title' => 'Station 2 · Skills',
+        'subtitle' => 'Finde meinen Lieblings-Stack',
+        'question' => 'Welche Kombi sorgt bei mir für schnelle Releases?',
+        'options' => [
+            ['label' => 'PHP 8 · Vanilla JS · Tailwindless CSS', 'correct' => true, 'proof' => 'Damit shippe ich CMS-Features ohne Framework-Overhead.'],
+            ['label' => 'Perl · Flash · Tables', 'correct' => false, 'proof' => 'Retro? Sicher. Produktiv? Nicht wirklich.'],
+            ['label' => 'Rust Backend · WebGL Frontend', 'correct' => false, 'proof' => 'Spannend, aber für KMUs overkill.']
+        ],
+        'achievement' => 'Skill-Pass freigeschaltet: Backend trifft UX-Feinschliff.'
+    ],
+    [
+        'id' => 'projects',
+        'title' => 'Station 3 · Projekte',
+        'subtitle' => 'Scan die Tickets, um Details zu erhalten',
+        'projects' => [
+            [
+                'name' => 'TeamTalk Live',
+                'summary' => 'Echtzeit-Kommunikations-App für Schichtbetriebe',
+                'details' => 'Push Notifications, Moderationstools und ein internes FAQ senkten Supportaufwände um 40 %.',
+                'tech' => 'PHP, WebSockets, Redis Pub/Sub',
+                'role' => 'Konzept, Fullstack-Implementierung, Monitoring'
+            ],
+            [
+                'name' => 'CityCMS Relaunch',
+                'summary' => 'Barrierearmer Auftritt für eine Stadtverwaltung',
+                'details' => 'Optimiertes CMS-Backend für 45 Redakteure, Lighthouse Performance 95+.',
+                'tech' => 'PHP, MySQL, Alpine.js',
+                'role' => 'Architektur, API-Integration, Schulung'
+            ],
+            [
+                'name' => 'Learning Rails',
+                'summary' => 'Gamifizierte Multiple-Choice-Lernstrecke',
+                'details' => 'Bringt Azubis durch kurze Quiz-Sprints zu 30 % besseren Ergebnissen.',
+                'tech' => 'PHP, Vanilla JS, IndexedDB',
+                'role' => 'Game Design, Frontend, Analytics'
+            ]
+        ],
+        'achievement' => 'Projektarchiv geöffnet: Proof geliefert.'
+    ],
+    [
+        'id' => 'personality',
+        'title' => 'Station 4 · Soft Skills',
+        'subtitle' => 'Schalte meine Crew-Karten frei',
+        'traits' => [
+            [
+                'name' => 'Crew Captain',
+                'description' => 'Übernimmt Daily Standups und sorgt für Fokus auf das Wichtige.'
+            ],
+            [
+                'name' => 'Bug Buster',
+                'description' => 'Tracking mit Feature-Toggles und Post-Mortems spart Zeit und Nerven.'
+            ],
+            [
+                'name' => 'Calm Communicator',
+                'description' => 'Auch unter Zeitdruck bleiben Stakeholder informiert und gelassen.'
+            ]
+        ],
+        'achievement' => 'Alle Crew-Karten eingesammelt. Ready for the final stop!'
+    ],
+];
+
+$cta = [
+    'message' => 'Bereit für eine gemeinsame Fahrt? Lass uns über dein nächstes Projekt sprechen.',
+    'contact' => [
+        'label' => 'Mail an Roland senden',
+        'href' => 'mailto:hey@roland.codes'
+    ],
+    'download' => [
+        'label' => 'CV als PDF',
+        'href' => '#'
+    ],
+    'surprise' => 'Easter Egg: dreifaches Tippen auf die Hupe verrät meinen Lieblings-Snack im Nightshift.'
+];
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rolands Interview-Express</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<header class="hero">
+    <div class="hero__content">
+        <h1><?= htmlspecialchars($profile['name']) ?> · <?= htmlspecialchars($profile['role']) ?></h1>
+        <p class="hero__tagline"><?= htmlspecialchars($profile['tagline']) ?></p>
+        <p class="hero__intro"><?= htmlspecialchars($profile['intro']) ?></p>
+        <button class="btn btn--primary" data-action="start">Fahrt starten</button>
+        <a class="btn btn--ghost" href="#final-stop">Direkt zum Kontakt</a>
+    </div>
+    <div class="hero__train" role="img" aria-label="Stilisierter Zug als Symbol für den Karriereweg"></div>
+</header>
+
+<main>
+    <section class="progress" aria-live="polite">
+        <div class="progress__bar"><span></span></div>
+        <p class="progress__label">Station 0 von <?= count($stations) ?></p>
+    </section>
+
+    <?php foreach ($stations as $index => $station): ?>
+        <section class="station" id="station-<?= htmlspecialchars($station['id']) ?>" data-station-index="<?= $index + 1 ?>" hidden>
+            <header>
+                <h2><?= htmlspecialchars($station['title']) ?></h2>
+                <p><?= htmlspecialchars($station['subtitle']) ?></p>
+            </header>
+
+            <?php if ($station['id'] === 'story'): ?>
+                <div class="choices">
+                    <?php foreach ($station['content'] as $key => $choice): ?>
+                        <button class="card card--choice" data-story-choice="<?= htmlspecialchars($key) ?>">
+                            <span><?= htmlspecialchars($choice['label']) ?></span>
+                        </button>
+                    <?php endforeach; ?>
+                </div>
+                <p class="station__result" data-result="story"></p>
+            <?php elseif ($station['id'] === 'skills'): ?>
+                <div class="quiz">
+                    <p class="quiz__question"><?= htmlspecialchars($station['question']) ?></p>
+                    <div class="quiz__options">
+                        <?php foreach ($station['options'] as $option): ?>
+                            <button class="card card--option" data-correct="<?= $option['correct'] ? 'true' : 'false' ?>" data-proof="<?= htmlspecialchars($option['proof']) ?>">
+                                <?= htmlspecialchars($option['label']) ?>
+                            </button>
+                        <?php endforeach; ?>
+                    </div>
+                    <p class="station__result" data-result="skills"></p>
+                </div>
+            <?php elseif ($station['id'] === 'projects'): ?>
+                <div class="project-grid">
+                    <?php foreach ($station['projects'] as $project): ?>
+                        <article class="card card--project" data-project>
+                            <h3><?= htmlspecialchars($project['name']) ?></h3>
+                            <p><?= htmlspecialchars($project['summary']) ?></p>
+                            <button class="btn btn--secondary" data-project-open>Ticket scannen</button>
+                            <dl class="project-details" hidden>
+                                <dt>Outcome</dt>
+                                <dd><?= htmlspecialchars($project['details']) ?></dd>
+                                <dt>Stack</dt>
+                                <dd><?= htmlspecialchars($project['tech']) ?></dd>
+                                <dt>Rolle</dt>
+                                <dd><?= htmlspecialchars($project['role']) ?></dd>
+                            </dl>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+                <p class="station__result" data-result="projects"></p>
+            <?php elseif ($station['id'] === 'personality'): ?>
+                <div class="traits">
+                    <?php foreach ($station['traits'] as $trait): ?>
+                        <button class="card card--trait" data-trait>
+                            <span class="trait__title"><?= htmlspecialchars($trait['name']) ?></span>
+                            <span class="trait__text" hidden><?= htmlspecialchars($trait['description']) ?></span>
+                        </button>
+                    <?php endforeach; ?>
+                </div>
+                <p class="station__result" data-result="personality"></p>
+            <?php endif; ?>
+
+            <footer class="station__footer">
+                <p class="achievement" data-achievement><?= htmlspecialchars($station['achievement']) ?></p>
+                <div class="nav">
+                    <button class="btn" data-action="prev">Zurück</button>
+                    <button class="btn btn--primary" data-action="next" disabled>Weiter</button>
+                </div>
+            </footer>
+        </section>
+    <?php endforeach; ?>
+
+    <section class="final" id="final-stop" hidden>
+        <h2>Endstation · Recruiting Hub</h2>
+        <p><?= htmlspecialchars($cta['message']) ?></p>
+        <div class="final__actions">
+            <a class="btn btn--primary" href="<?= htmlspecialchars($cta['contact']['href']) ?>"><?= htmlspecialchars($cta['contact']['label']) ?></a>
+            <a class="btn btn--ghost" href="<?= htmlspecialchars($cta['download']['href']) ?>"><?= htmlspecialchars($cta['download']['label']) ?></a>
+        </div>
+        <p class="final__surprise"><?= htmlspecialchars($cta['surprise']) ?></p>
+        <button class="btn btn--secondary" data-action="replay">Noch einmal fahren</button>
+    </section>
+</main>
+
+<footer class="footer">
+    <p>© <?= date('Y') ?> Roland Burmberger · Mit Liebe und purem PHP gefertigt.</p>
+    <button class="btn btn--ghost" data-horn>Hupe</button>
+    <span class="horn-secret" aria-live="polite"></span>
+</footer>
+
+<script src="assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a PHP-driven "Interview-Express" portfolio page with hero, progress tracking, and four interactive stations for story, skills, projects, and soft skills
- add CSS styling and state indicators for cards, progress bar, and final CTA section
- implement JavaScript game logic for station navigation, micro-interactions, replay reset, and footer Easter egg
- document project structure and local PHP dev instructions

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68caf5a209608325a59bcf35517e5701