### PR TITLE
Build Debug Dash platformer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# TheGame
+# Rolands Debug Dash
+
+Ein 2D-Portfolio-Platformer für Bewerbungen: Recruiter steuern Roland Burmberger per WASD durch drei Level, springen über Schluchten, zerquetschen Bugs, sammeln Kaffee für HP und lösen ein Bonus-Puzzle für Extrapunkte.
+
+## Features
+- **Direkte Steuerung:** WASD/Arrow-Keys + Leertaste für die Debug-Kanone. Springe auf Bugs oder schieße sie mit freigeschalteter Waffe ab.
+- **Lebensverwaltung:** HP-Balken, Leben und Score im HUD. Kaffee heilt, Puzzle-Bonus pusht HP + Punkte.
+- **Level-Design:** Drei Level mit Pits, beweglichen Gegnern, Sammelobjekten, Exit-Portalen und einem finalen Victory-Screen.
+- **Bonus-Minispiel:** Drag-and-Drop-Codepuzzle nach jedem Level für zusätzliche Ressourcen.
+- **Reines Frontend:** Kein Framework, nur PHP als Wrapper für statisches HTML, CSS und Vanilla JavaScript.
+
+## Starten
+```bash
+php -S localhost:8000
+```
+
+Danach im Browser `http://localhost:8000/index.php` öffnen.
+
+## Projektstruktur
+- `index.php` – HTML-Grundgerüst, HUD, Overlays und Canvas.
+- `assets/style.css` – Neon-Night-Styling, HUD, Overlays, Puzzle-Look.
+- `assets/script.js` – Canvas-Plattformer, Gegner-Logik, Puzzle-System, HUD-Updates.
+
+Viel Spaß beim Bug-Hopping! ☕🐛

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,908 @@
+(() => {
+    const canvas = document.getElementById('game-canvas');
+    const ctx = canvas.getContext('2d');
+
+    const TILE_SIZE = 48;
+    const GRAVITY = 0.9;
+    const MOVE_ACCEL = 0.7;
+    const MAX_SPEED = 6;
+    const JUMP_FORCE = 16;
+    const FRICTION = 0.85;
+    const PLAYER_WIDTH = 32;
+    const PLAYER_HEIGHT = 46;
+
+    const LEVELS = [
+        {
+            name: 'Onboarding-Werkstatt',
+            tiles: [
+                '....................',
+                '....................',
+                '....S...............',
+                '....................',
+                '...===..............',
+                '.............C......',
+                '..C....B............',
+                '#####.....====......',
+                '..P........W....E...',
+                '##########..#######.',
+                '##########..#######.',
+                '####################'
+            ]
+        },
+        {
+            name: 'Sprint der Schluchten',
+            tiles: [
+                '....................',
+                '.....S..............',
+                '............C.......',
+                '..........====......',
+                '..C.................',
+                '....====.......B....',
+                '###......#####......',
+                '..P....W......E.....',
+                '####..#######..#####',
+                '####..#######..#####',
+                '####...............#',
+                '####################'
+            ]
+        },
+        {
+            name: 'Release-Party',
+            tiles: [
+                '....................',
+                '....S...............',
+                '..........C.........',
+                '....====.......====.',
+                '....................',
+                '..B......W.....B....',
+                '#####..######..#####',
+                '..P............E....',
+                '####..########..####',
+                '####..########..####',
+                '####...............#',
+                '####################'
+            ]
+        }
+    ];
+
+    const hud = {
+        level: document.getElementById('level-indicator'),
+        hp: document.getElementById('hp-fill'),
+        lives: document.getElementById('life-counter'),
+        score: document.getElementById('score-counter'),
+        weapon: document.getElementById('weapon-indicator')
+    };
+
+    const overlays = {
+        tutorial: document.getElementById('tutorial'),
+        levelComplete: document.getElementById('level-complete'),
+        puzzle: document.getElementById('puzzle-overlay'),
+        gameOver: document.getElementById('game-over'),
+        victory: document.getElementById('victory')
+    };
+
+    const weaponToast = document.getElementById('weapon-unlock');
+    const startButton = document.getElementById('start-button');
+    const puzzleButton = document.getElementById('puzzle-button');
+    const puzzleReset = document.getElementById('puzzle-reset');
+    const levelSummary = document.getElementById('level-summary');
+    const victorySummary = document.getElementById('victory-summary');
+
+    const puzzlePiecesContainer = document.querySelector('.puzzle__pieces');
+    const puzzlePieces = Array.from(document.querySelectorAll('.puzzle-piece'));
+    const puzzleSlots = Array.from(document.querySelectorAll('.puzzle-slot'));
+
+    const restartButtons = Array.from(document.querySelectorAll('[data-action="restart"]'));
+
+    const keys = {
+        left: false,
+        right: false,
+        jump: false
+    };
+
+    let state = {
+        current: 'tutorial',
+        levelIndex: 0,
+        score: 0,
+        awaitingNextLevel: false
+    };
+
+    let level = null;
+    let player = null;
+    let enemies = [];
+    let coffees = [];
+    let snippets = [];
+    let weapon = null;
+    let exit = null;
+    let projectiles = [];
+    let spawnPoint = { x: 0, y: 0 };
+
+    let lastTime = 0;
+
+    function createPlayer(spawn) {
+        return {
+            x: spawn.x,
+            y: spawn.y,
+            width: PLAYER_WIDTH,
+            height: PLAYER_HEIGHT,
+            vx: 0,
+            vy: 0,
+            onGround: false,
+            hasWeapon: false,
+            weaponCooldown: 0,
+            facing: 1,
+            hp: 100,
+            maxHP: 100,
+            lives: 3,
+            invulnerable: 0
+        };
+    }
+
+    function openOverlay(el) {
+        el.hidden = false;
+        el.classList.add('visible');
+    }
+
+    function closeOverlay(el) {
+        el.classList.remove('visible');
+        setTimeout(() => {
+            el.hidden = true;
+        }, 50);
+    }
+
+    function resetPuzzle() {
+        puzzlePieces.forEach(piece => {
+            piece.dataset.locked = 'false';
+            piece.setAttribute('draggable', 'true');
+            piece.style.removeProperty('top');
+            piece.style.removeProperty('left');
+            piece.style.removeProperty('position');
+            piece.classList.remove('correct');
+            puzzlePiecesContainer.appendChild(piece);
+        });
+        puzzleSlots.forEach(slot => {
+            slot.dataset.filled = 'false';
+            slot.textContent = slot.dataset.accept === 'api'
+                ? 'API-Endpunkt'
+                : slot.dataset.accept === 'ui'
+                    ? 'Frontend'
+                    : 'Deployment';
+            slot.classList.remove('shake');
+        });
+    }
+
+    function shufflePuzzlePieces() {
+        const container = document.querySelector('.puzzle__pieces');
+        const shuffled = puzzlePieces.slice().sort(() => Math.random() - 0.5);
+        shuffled.forEach(piece => container.appendChild(piece));
+    }
+
+    function initPuzzle() {
+        resetPuzzle();
+        shufflePuzzlePieces();
+    }
+
+    function setupPuzzleDnD() {
+        puzzlePieces.forEach(piece => {
+            piece.addEventListener('dragstart', event => {
+                if (piece.dataset.locked === 'true') {
+                    event.preventDefault();
+                    return;
+                }
+                event.dataTransfer.setData('text/plain', piece.dataset.id);
+                setTimeout(() => piece.classList.add('dragging'), 0);
+            });
+
+            piece.addEventListener('dragend', () => {
+                piece.classList.remove('dragging');
+            });
+        });
+
+        puzzleSlots.forEach(slot => {
+            slot.addEventListener('dragover', event => {
+                event.preventDefault();
+            });
+
+            slot.addEventListener('drop', event => {
+                event.preventDefault();
+                const pieceId = event.dataTransfer.getData('text/plain');
+                const piece = puzzlePieces.find(p => p.dataset.id === pieceId);
+                if (!piece || piece.dataset.locked === 'true') {
+                    return;
+                }
+
+                if (slot.dataset.accept === pieceId) {
+                    slot.dataset.filled = 'true';
+                    slot.classList.remove('shake');
+                    slot.textContent = '';
+                    piece.dataset.locked = 'true';
+                    piece.setAttribute('draggable', 'false');
+                    piece.classList.add('correct');
+                    slot.appendChild(piece);
+                    piece.style.position = 'static';
+                    checkPuzzleCompletion();
+                } else {
+                    slot.classList.add('shake');
+                    setTimeout(() => slot.classList.remove('shake'), 400);
+                }
+            });
+        });
+    }
+
+    function checkPuzzleCompletion() {
+        const solved = puzzleSlots.every(slot => slot.dataset.filled === 'true');
+        if (!solved) {
+            return;
+        }
+        state.score += 500;
+        player.hp = Math.min(player.maxHP, player.hp + 30);
+        updateHUD();
+        closeOverlay(overlays.puzzle);
+        state.awaitingNextLevel = false;
+
+        if (state.levelIndex < LEVELS.length - 1) {
+            state.levelIndex += 1;
+            loadLevel(state.levelIndex, true);
+        } else {
+            showVictory();
+        }
+    }
+
+    function updateHUD() {
+        const hpPercent = Math.max(0, Math.min(100, Math.round((player.hp / player.maxHP) * 100)));
+        hud.hp.style.width = `${hpPercent}%`;
+        hud.lives.textContent = String(player.lives);
+        hud.score.textContent = String(state.score);
+        hud.level.textContent = `${state.levelIndex + 1} / ${LEVELS.length}`;
+        hud.weapon.textContent = player.hasWeapon ? 'Debug-Kanone' : 'Keine';
+    }
+
+    function loadLevel(index, keepStats = false) {
+        state.current = 'running';
+        state.awaitingNextLevel = false;
+        const definition = LEVELS[index];
+        const layout = definition.tiles.map(row => row.split(''));
+        enemies = [];
+        coffees = [];
+        snippets = [];
+        projectiles = [];
+        weapon = null;
+        exit = null;
+
+        for (let y = 0; y < layout.length; y += 1) {
+            for (let x = 0; x < layout[y].length; x += 1) {
+                const char = layout[y][x];
+                const worldX = x * TILE_SIZE;
+                const worldY = y * TILE_SIZE;
+
+                switch (char) {
+                    case 'P':
+                        spawnPoint = {
+                            x: worldX + 8,
+                            y: worldY + TILE_SIZE - PLAYER_HEIGHT - 2
+                        };
+                        layout[y][x] = '.';
+                        break;
+                    case 'B':
+                        enemies.push({
+                            x: worldX + 8,
+                            y: worldY + 10,
+                            width: 32,
+                            height: 30,
+                            vx: Math.random() > 0.5 ? 1.2 : -1.2,
+                            range: 96,
+                            originX: worldX + 8,
+                            alive: true
+                        });
+                        layout[y][x] = '.';
+                        break;
+                    case 'C':
+                        coffees.push({
+                            x: worldX + 10,
+                            y: worldY + 14,
+                            width: 28,
+                            height: 30
+                        });
+                        layout[y][x] = '.';
+                        break;
+                    case 'S':
+                        snippets.push({
+                            x: worldX + 10,
+                            y: worldY + 10,
+                            width: 28,
+                            height: 28,
+                            pulse: Math.random() * Math.PI * 2
+                        });
+                        layout[y][x] = '.';
+                        break;
+                    case 'W':
+                        weapon = {
+                            x: worldX + 8,
+                            y: worldY + 6,
+                            width: 32,
+                            height: 32,
+                            collected: false
+                        };
+                        layout[y][x] = '.';
+                        break;
+                    case 'E':
+                        exit = {
+                            x: worldX + 4,
+                            y: worldY + 4,
+                            width: TILE_SIZE - 8,
+                            height: TILE_SIZE - 8
+                        };
+                        layout[y][x] = '.';
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        level = {
+            name: definition.name,
+            layout,
+            width: layout[0].length,
+            height: layout.length
+        };
+
+        const previousStats = player
+            ? { hp: player.hp, lives: player.lives }
+            : null;
+
+        if (!keepStats || !player) {
+            player = createPlayer(spawnPoint);
+            if (!keepStats) {
+                state.score = 0;
+            }
+        } else {
+            player.x = spawnPoint.x;
+            player.y = spawnPoint.y;
+            player.vx = 0;
+            player.vy = 0;
+            player.onGround = false;
+            player.hasWeapon = false;
+            player.weaponCooldown = 0;
+        }
+
+        if (keepStats && previousStats) {
+            player.hp = Math.min(player.maxHP, previousStats.hp);
+            player.lives = previousStats.lives;
+        } else {
+            player.hp = player.maxHP;
+            player.lives = 3;
+        }
+        player.invulnerable = 0;
+
+        updateHUD();
+    }
+
+    function isSolidTile(tileX, tileY) {
+        if (tileY >= level.height) {
+            return true;
+        }
+        if (tileY < 0) {
+            return false;
+        }
+        if (tileX < 0 || tileX >= level.width) {
+            return true;
+        }
+        const tile = level.layout[tileY][tileX];
+        return tile === '#' || tile === '=';
+    }
+
+    function resolveCollisions(entity, axis) {
+        const { width, height } = entity;
+        if (axis === 'x') {
+            const dir = Math.sign(entity.vx);
+            if (dir === 0) {
+                return;
+            }
+            const nextX = entity.x + entity.vx;
+            const xEdge = dir > 0 ? nextX + width : nextX;
+            const tileX = Math.floor(xEdge / TILE_SIZE);
+            const topTile = Math.floor(entity.y / TILE_SIZE);
+            const bottomTile = Math.floor((entity.y + height - 1) / TILE_SIZE);
+
+            for (let ty = topTile; ty <= bottomTile; ty += 1) {
+                if (isSolidTile(tileX, ty)) {
+                    if (dir > 0) {
+                        entity.x = tileX * TILE_SIZE - width - 0.1;
+                    } else {
+                        entity.x = (tileX + 1) * TILE_SIZE + 0.1;
+                    }
+                    entity.vx = 0;
+                    return;
+                }
+            }
+            entity.x = nextX;
+        } else {
+            const nextY = entity.y + entity.vy;
+            const dirY = Math.sign(entity.vy);
+            const yEdge = dirY > 0 ? nextY + height : nextY;
+            const tileY = Math.floor(yEdge / TILE_SIZE);
+            const leftTile = Math.floor(entity.x / TILE_SIZE);
+            const rightTile = Math.floor((entity.x + width - 1) / TILE_SIZE);
+
+            for (let tx = leftTile; tx <= rightTile; tx += 1) {
+                if (isSolidTile(tx, tileY)) {
+                    if (dirY > 0) {
+                        entity.y = tileY * TILE_SIZE - height - 0.1;
+                        entity.vy = 0;
+                        if (entity === player) {
+                            player.onGround = true;
+                        }
+                    } else {
+                        entity.y = (tileY + 1) * TILE_SIZE + 0.1;
+                        entity.vy = 0;
+                    }
+                    return;
+                }
+            }
+            entity.y = nextY;
+        }
+    }
+
+    function rectsOverlap(a, b) {
+        return (
+            a.x < b.x + b.width &&
+            a.x + a.width > b.x &&
+            a.y < b.y + b.height &&
+            a.y + a.height > b.y
+        );
+    }
+
+    function collectItems() {
+        coffees = coffees.filter(cup => {
+            if (rectsOverlap(player, cup)) {
+                player.hp = Math.min(player.maxHP, player.hp + 25);
+                state.score += 200;
+                updateHUD();
+                return false;
+            }
+            return true;
+        });
+
+        snippets = snippets.filter(snippet => {
+            if (rectsOverlap(player, snippet)) {
+                state.score += 150;
+                updateHUD();
+                return false;
+            }
+            return true;
+        });
+
+        if (weapon && !weapon.collected && rectsOverlap(player, weapon)) {
+            weapon.collected = true;
+            player.hasWeapon = true;
+            state.score += 250;
+            showWeaponToast('Debug-Kanone freigeschaltet! Drücke die Leertaste.');
+            updateHUD();
+        }
+    }
+
+    function handleExit() {
+        if (!exit) {
+            return;
+        }
+        if (rectsOverlap(player, exit)) {
+            completeLevel();
+        }
+    }
+
+    function completeLevel() {
+        state.current = 'levelComplete';
+        state.awaitingNextLevel = true;
+        levelSummary.textContent = `Du hast ${state.score} Punkte gesammelt und ${player.lives} Leben übrig.`;
+        puzzleButton.textContent = state.levelIndex === LEVELS.length - 1
+            ? 'Finales Bonus-Puzzle'
+            : 'Zum Bonus-Puzzle';
+        closeOverlay(overlays.gameOver);
+        openOverlay(overlays.levelComplete);
+    }
+
+    function showWeaponToast(message) {
+        weaponToast.textContent = message;
+        weaponToast.hidden = false;
+        weaponToast.style.animation = 'none';
+        // Force reflow to restart animation
+        void weaponToast.offsetWidth;
+        weaponToast.style.animation = '';
+        setTimeout(() => {
+            weaponToast.hidden = true;
+        }, 2400);
+    }
+
+    function applyDamage(amount) {
+        if (player.invulnerable > 0 || state.current !== 'running') {
+            return;
+        }
+        player.hp -= amount;
+        player.invulnerable = 60;
+        if (player.hp <= 0) {
+            player.lives -= 1;
+            updateHUD();
+            if (player.lives > 0) {
+                player.hp = player.maxHP;
+                player.x = spawnPoint.x;
+                player.y = spawnPoint.y;
+                player.vx = 0;
+                player.vy = 0;
+                player.onGround = false;
+            } else {
+                player.hp = 0;
+                updateHUD();
+                triggerGameOver();
+                return;
+            }
+        }
+        updateHUD();
+    }
+
+    function triggerGameOver() {
+        state.current = 'gameover';
+        openOverlay(overlays.gameOver);
+    }
+
+    function showVictory() {
+        state.current = 'victory';
+        victorySummary.textContent = `Score: ${state.score} · Leben übrig: ${Math.max(player.lives, 0)}`;
+        openOverlay(overlays.victory);
+    }
+
+    function fireWeapon() {
+        if (!player.hasWeapon || player.weaponCooldown > 0) {
+            return;
+        }
+        const projectile = {
+            x: player.x + (player.facing > 0 ? player.width : -16),
+            y: player.y + player.height / 2,
+            width: 16,
+            height: 6,
+            vx: player.facing > 0 ? 12 : -12,
+            ttl: 60
+        };
+        projectiles.push(projectile);
+        player.weaponCooldown = 15;
+    }
+
+    function updateProjectiles() {
+        projectiles = projectiles.filter(projectile => {
+            projectile.x += projectile.vx;
+            projectile.ttl -= 1;
+            if (projectile.ttl <= 0) {
+                return false;
+            }
+            for (const enemy of enemies) {
+                if (!enemy.alive) {
+                    continue;
+                }
+                if (rectsOverlap(projectile, enemy)) {
+                    enemy.alive = false;
+                    state.score += 200;
+                    updateHUD();
+                    return false;
+                }
+            }
+            const tileX = Math.floor(projectile.x / TILE_SIZE);
+            const tileY = Math.floor(projectile.y / TILE_SIZE);
+            if (isSolidTile(tileX, tileY)) {
+                return false;
+            }
+            return projectile.x > -32 && projectile.x < canvas.width + 32;
+        });
+    }
+
+    function updateEnemies() {
+        enemies.forEach(enemy => {
+            if (!enemy.alive) {
+                return;
+            }
+            enemy.x += enemy.vx;
+            const tileBelow = Math.floor((enemy.y + enemy.height + 2) / TILE_SIZE);
+            const frontX = enemy.vx > 0 ? enemy.x + enemy.width + 2 : enemy.x - 2;
+            const tileFront = Math.floor(frontX / TILE_SIZE);
+            const tileY = Math.floor(enemy.y / TILE_SIZE);
+
+            if (isSolidTile(tileFront, tileY) || !isSolidTile(tileFront, tileBelow)) {
+                enemy.vx *= -1;
+            }
+
+            if (rectsOverlap(player, enemy)) {
+                if (player.vy > 0 && player.y + player.height - enemy.y < enemy.height) {
+                    enemy.alive = false;
+                    player.vy = -10;
+                    state.score += 250;
+                    updateHUD();
+                } else {
+                    applyDamage(35);
+                }
+            }
+        });
+    }
+
+    function updatePlayer(delta) {
+        if (keys.left) {
+            player.vx = Math.max(player.vx - MOVE_ACCEL * delta, -MAX_SPEED);
+            player.facing = -1;
+        } else if (keys.right) {
+            player.vx = Math.min(player.vx + MOVE_ACCEL * delta, MAX_SPEED);
+            player.facing = 1;
+        } else {
+            player.vx *= FRICTION;
+            if (Math.abs(player.vx) < 0.05) {
+                player.vx = 0;
+            }
+        }
+
+        player.vy += GRAVITY * delta;
+        if (player.vy > 18) {
+            player.vy = 18;
+        }
+
+        player.onGround = false;
+        resolveCollisions(player, 'x');
+        resolveCollisions(player, 'y');
+
+        if (player.y > canvas.height + 64) {
+            applyDamage(player.maxHP);
+            player.x = spawnPoint.x;
+            player.y = spawnPoint.y;
+            player.vx = 0;
+            player.vy = 0;
+        }
+
+        if (player.weaponCooldown > 0) {
+            player.weaponCooldown -= 1;
+        }
+        if (player.invulnerable > 0) {
+            player.invulnerable -= 1;
+        }
+    }
+
+    function update(delta) {
+        if (state.current !== 'running') {
+            return;
+        }
+        updatePlayer(delta);
+        updateEnemies();
+        updateProjectiles();
+        collectItems();
+        handleExit();
+    }
+
+    function drawBackground() {
+        const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+        gradient.addColorStop(0, '#0f172a');
+        gradient.addColorStop(1, '#020617');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+
+    function drawTiles() {
+        for (let y = 0; y < level.height; y += 1) {
+            for (let x = 0; x < level.width; x += 1) {
+                const tile = level.layout[y][x];
+                if (tile === '#') {
+                    ctx.fillStyle = '#1e293b';
+                    ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+                    ctx.fillStyle = '#0f172a';
+                    ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE + TILE_SIZE - 12, TILE_SIZE, 12);
+                } else if (tile === '=') {
+                    ctx.fillStyle = '#334155';
+                    ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE + TILE_SIZE / 2, TILE_SIZE, TILE_SIZE / 2);
+                    ctx.fillStyle = '#38bdf8';
+                    ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE + TILE_SIZE / 2 - 4, TILE_SIZE, 4);
+                }
+            }
+        }
+    }
+
+    function drawPlayer() {
+        ctx.save();
+        ctx.translate(player.x + player.width / 2, player.y + player.height / 2);
+        if (player.facing < 0) {
+            ctx.scale(-1, 1);
+        }
+        const alpha = player.invulnerable > 0 ? 0.5 + Math.sin(Date.now() / 60) * 0.3 : 1;
+        ctx.globalAlpha = alpha;
+        ctx.fillStyle = '#38bdf8';
+        ctx.fillRect(-player.width / 2, -player.height / 2, player.width, player.height);
+        ctx.fillStyle = '#0f172a';
+        ctx.fillRect(-player.width / 2 + 6, -player.height / 2 + 6, player.width - 12, player.height - 20);
+        ctx.fillStyle = '#facc15';
+        ctx.fillRect(-player.width / 2 + 4, player.height / 2 - 14, player.width - 8, 8);
+        ctx.fillStyle = '#e2e8f0';
+        ctx.beginPath();
+        ctx.arc(player.width / 2 - 12, -player.height / 2 + 14, 6, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+        ctx.globalAlpha = 1;
+    }
+
+    function drawEnemies() {
+        enemies.forEach(enemy => {
+            if (!enemy.alive) {
+                return;
+            }
+            ctx.save();
+            ctx.translate(enemy.x + enemy.width / 2, enemy.y + enemy.height / 2);
+            ctx.fillStyle = '#ef4444';
+            ctx.beginPath();
+            ctx.ellipse(0, 0, enemy.width / 2, enemy.height / 2, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.strokeStyle = '#0f172a';
+            ctx.lineWidth = 2;
+            for (let i = -1; i <= 1; i += 1) {
+                ctx.beginPath();
+                ctx.moveTo(i * 10, enemy.height / 2);
+                ctx.lineTo(i * 10 + (i === 0 ? 0 : 6 * Math.sign(i)), enemy.height / 2 + 12);
+                ctx.stroke();
+            }
+            ctx.fillStyle = '#facc15';
+            ctx.beginPath();
+            ctx.arc(-6, -4, 4, 0, Math.PI * 2);
+            ctx.arc(6, -4, 4, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        });
+    }
+
+    function drawCollectibles() {
+        coffees.forEach(cup => {
+            ctx.fillStyle = '#facc15';
+            ctx.fillRect(cup.x, cup.y, cup.width, cup.height);
+            ctx.fillStyle = '#0f172a';
+            ctx.fillRect(cup.x + 4, cup.y + 4, cup.width - 8, cup.height - 10);
+            ctx.fillStyle = '#f97316';
+            ctx.fillRect(cup.x + 6, cup.y + 4, cup.width - 12, 6);
+        });
+
+        snippets.forEach(snippet => {
+            const pulse = 4 * Math.sin(Date.now() / 200 + snippet.pulse);
+            ctx.save();
+            ctx.translate(snippet.x + snippet.width / 2, snippet.y + snippet.height / 2);
+            ctx.rotate(Math.sin(Date.now() / 400 + snippet.pulse) * 0.1);
+            ctx.fillStyle = '#a855f7';
+            ctx.fillRect(-snippet.width / 2, -snippet.height / 2, snippet.width, snippet.height);
+            ctx.fillStyle = '#f8fafc';
+            ctx.fillRect(-snippet.width / 2 + 4, -snippet.height / 2 + 4, snippet.width - 8, snippet.height - 8);
+            ctx.restore();
+            ctx.fillStyle = '#38bdf8';
+            ctx.fillRect(snippet.x + snippet.width / 2 - 2, snippet.y + snippet.height + pulse, 4, 6 + pulse);
+        });
+
+        if (weapon && !weapon.collected) {
+            ctx.save();
+            ctx.translate(weapon.x + weapon.width / 2, weapon.y + weapon.height / 2);
+            ctx.rotate(Math.sin(Date.now() / 200) * 0.1);
+            ctx.fillStyle = '#38bdf8';
+            ctx.fillRect(-weapon.width / 2, -weapon.height / 2, weapon.width, weapon.height);
+            ctx.fillStyle = '#0f172a';
+            ctx.fillRect(-weapon.width / 2 + 6, -weapon.height / 2 + 6, weapon.width - 12, weapon.height - 12);
+            ctx.strokeStyle = '#facc15';
+            ctx.lineWidth = 3;
+            ctx.strokeRect(-weapon.width / 2 + 4, -weapon.height / 2 + 4, weapon.width - 8, weapon.height - 8);
+            ctx.restore();
+        }
+
+        if (exit) {
+            ctx.save();
+            ctx.translate(exit.x + exit.width / 2, exit.y + exit.height / 2);
+            const gradient = ctx.createRadialGradient(0, 0, 6, 0, 0, exit.width / 2);
+            gradient.addColorStop(0, '#38bdf8');
+            gradient.addColorStop(1, 'rgba(14, 165, 233, 0.2)');
+            ctx.fillStyle = gradient;
+            ctx.beginPath();
+            ctx.arc(0, 0, exit.width / 2, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.strokeStyle = '#38bdf8';
+            ctx.lineWidth = 3;
+            ctx.stroke();
+            ctx.restore();
+        }
+    }
+
+    function drawProjectiles() {
+        ctx.fillStyle = '#f8fafc';
+        projectiles.forEach(projectile => {
+            ctx.fillRect(projectile.x, projectile.y, projectile.width, projectile.height);
+        });
+    }
+
+    function render() {
+        drawBackground();
+        if (!level) {
+            return;
+        }
+        drawTiles();
+        drawCollectibles();
+        drawEnemies();
+        drawProjectiles();
+        drawPlayer();
+    }
+
+    function gameLoop(timestamp) {
+        const delta = Math.min(2, (timestamp - lastTime) / 16.67 || 1);
+        lastTime = timestamp;
+        update(delta);
+        render();
+        requestAnimationFrame(gameLoop);
+    }
+
+    function startGame() {
+        closeOverlay(overlays.tutorial);
+        state.levelIndex = 0;
+        state.score = 0;
+        player = null;
+        loadLevel(0);
+        updateHUD();
+    }
+
+    function restartGame() {
+        closeOverlay(overlays.gameOver);
+        closeOverlay(overlays.victory);
+        state.score = 0;
+        player = null;
+        state.levelIndex = 0;
+        loadLevel(0);
+        updateHUD();
+    }
+
+    startButton.addEventListener('click', () => {
+        state.current = 'running';
+        startGame();
+    });
+
+    puzzleButton.addEventListener('click', () => {
+        if (!state.awaitingNextLevel) {
+            return;
+        }
+        closeOverlay(overlays.levelComplete);
+        initPuzzle();
+        state.current = 'puzzle';
+        openOverlay(overlays.puzzle);
+    });
+
+    puzzleReset.addEventListener('click', () => {
+        initPuzzle();
+    });
+
+    restartButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            restartGame();
+        });
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'ArrowLeft' || event.key === 'a' || event.key === 'A') {
+            keys.left = true;
+        }
+        if (event.key === 'ArrowRight' || event.key === 'd' || event.key === 'D') {
+            keys.right = true;
+        }
+        if ((event.key === 'ArrowUp' || event.key === 'w' || event.key === 'W') && player && player.onGround && state.current === 'running') {
+            player.vy = -JUMP_FORCE;
+            player.onGround = false;
+        }
+        if (event.key === ' ' || event.code === 'Space') {
+            event.preventDefault();
+            if (state.current === 'running') {
+                fireWeapon();
+            }
+        }
+    });
+
+    document.addEventListener('keyup', event => {
+        if (event.key === 'ArrowLeft' || event.key === 'a' || event.key === 'A') {
+            keys.left = false;
+        }
+        if (event.key === 'ArrowRight' || event.key === 'd' || event.key === 'D') {
+            keys.right = false;
+        }
+    });
+
+    setupPuzzleDnD();
+    requestAnimationFrame(gameLoop);
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,317 @@
+:root {
+    --bg: #0f172a;
+    --bg-accent: #1e293b;
+    --primary: #38bdf8;
+    --primary-dark: #0ea5e9;
+    --accent: #facc15;
+    --danger: #ef4444;
+    --success: #34d399;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --shadow: 0 18px 40px rgba(15, 23, 42, 0.55);
+    font-size: clamp(14px, 1vw + 10px, 18px);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: 'Segoe UI', Roboto, sans-serif;
+    background: radial-gradient(circle at top, #1e3a8a 0%, #0f172a 40%, #020617 100%);
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+main {
+    width: min(100%, 1024px);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+canvas {
+    width: 100%;
+    border-radius: 1rem;
+    background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+    box-shadow: var(--shadow);
+    border: 3px solid rgba(56, 189, 248, 0.35);
+}
+
+.hud {
+    width: min(100%, 1024px);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.75rem;
+    margin: 1.5rem 1.5rem 0;
+    padding: 1rem 1.25rem;
+    border-radius: 0.75rem;
+    background: rgba(15, 23, 42, 0.85);
+    backdrop-filter: blur(12px);
+    box-shadow: var(--shadow);
+}
+
+.hud__group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.hud__group span:last-child {
+    color: var(--text);
+}
+
+.hud__group--hp {
+    min-width: 160px;
+}
+
+.hud__label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.hp-bar {
+    position: relative;
+    flex: 1;
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.25);
+    overflow: hidden;
+}
+
+#hp-fill {
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(90deg, var(--success), var(--primary));
+    transition: width 0.25s ease;
+}
+
+.btn {
+    border: none;
+    border-radius: 999px;
+    padding: 0.75rem 1.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    background: rgba(148, 163, 184, 0.2);
+    color: var(--text);
+    transition: transform 0.2s ease, background 0.3s ease;
+}
+
+.btn:hover,
+.btn:focus {
+    transform: translateY(-2px);
+}
+
+.btn--primary {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+    color: #0f172a;
+}
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(2, 6, 23, 0.85);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    padding: 1.5rem;
+    z-index: 10;
+}
+
+.overlay.visible {
+    display: flex;
+}
+
+.overlay__content {
+    background: rgba(15, 23, 42, 0.95);
+    border-radius: 1rem;
+    padding: 2rem;
+    width: min(640px, 100%);
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    text-align: left;
+}
+
+.overlay__content--wide {
+    width: min(720px, 100%);
+}
+
+.tutorial-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    background: rgba(148, 163, 184, 0.2);
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.toast {
+    position: absolute;
+    inset: auto 50% 2rem;
+    transform: translateX(50%);
+    background: rgba(56, 189, 248, 0.95);
+    color: #0f172a;
+    padding: 1rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 700;
+    box-shadow: var(--shadow);
+    animation: pop-in 0.4s ease, float 3s ease-in-out infinite;
+}
+
+@keyframes pop-in {
+    from {
+        opacity: 0;
+        transform: translate(50%, 20px) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translate(50%, 0) scale(1);
+    }
+}
+
+@keyframes float {
+    0%, 100% {
+        transform: translate(50%, 0);
+    }
+    50% {
+        transform: translate(50%, -6px);
+    }
+}
+
+@keyframes shake {
+    0%, 100% {
+        transform: translateX(0);
+    }
+    25% {
+        transform: translateX(-6px);
+    }
+    75% {
+        transform: translateX(6px);
+    }
+}
+
+.puzzle {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.puzzle__board {
+    display: grid;
+    gap: 1rem;
+}
+
+.puzzle-slot {
+    min-height: 72px;
+    border: 2px dashed rgba(148, 163, 184, 0.6);
+    border-radius: 0.85rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+    font-weight: 600;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.puzzle-slot.shake {
+    animation: shake 0.3s;
+    border-color: var(--danger);
+}
+
+.puzzle-slot[data-filled="true"] {
+    border-style: solid;
+    border-color: var(--success);
+    background: rgba(52, 211, 153, 0.2);
+    color: var(--success);
+}
+
+.puzzle-slot .puzzle-piece {
+    width: 100%;
+    text-align: center;
+}
+
+.puzzle__pieces {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.puzzle-piece {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    background: rgba(56, 189, 248, 0.18);
+    border: 2px solid rgba(56, 189, 248, 0.55);
+    cursor: grab;
+    font-weight: 600;
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.puzzle-piece:active {
+    cursor: grabbing;
+    transform: scale(1.03);
+    box-shadow: var(--shadow);
+}
+
+.puzzle-piece[data-locked="true"] {
+    cursor: default;
+    background: rgba(52, 211, 153, 0.25);
+    border-color: var(--success);
+    color: var(--success);
+}
+
+.puzzle__actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+#game-area {
+    position: relative;
+}
+
+#game-over.visible,
+#victory.visible,
+#level-complete.visible {
+    display: flex;
+}
+
+@media (max-width: 768px) {
+    .hud {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.5rem;
+        font-size: 0.95rem;
+    }
+
+    .hud__group {
+        justify-content: space-between;
+    }
+
+    .overlay__content {
+        padding: 1.5rem;
+    }
+
+    .btn {
+        width: 100%;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rolands Debug Dash</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<header class="hud" aria-live="polite">
+    <div class="hud__group">
+        <span class="hud__label">Level</span>
+        <span id="level-indicator">Tutorial</span>
+    </div>
+    <div class="hud__group hud__group--hp">
+        <span class="hud__label">HP</span>
+        <div class="hp-bar" role="img" aria-label="Lebensbalken">
+            <div id="hp-fill"></div>
+        </div>
+    </div>
+    <div class="hud__group">
+        <span class="hud__label">Leben</span>
+        <span id="life-counter">3</span>
+    </div>
+    <div class="hud__group">
+        <span class="hud__label">Score</span>
+        <span id="score-counter">0</span>
+    </div>
+    <div class="hud__group">
+        <span class="hud__label">Waffe</span>
+        <span id="weapon-indicator">Keine</span>
+    </div>
+</header>
+<main>
+    <section id="tutorial" class="overlay visible" role="dialog" aria-modal="true">
+        <div class="overlay__content">
+            <h1>Willkommen bei Rolands Debug Dash</h1>
+            <p>Steuere Roland mit <strong>WASD</strong> oder den Pfeiltasten. Springe auf Bugs, sammle Kaffee für Heilung und sichere dir Debug-Werkzeuge. Jeder Level endet mit einem Mini-Puzzle, das zusätzliche HP und Punkte bringt.</p>
+            <ul class="tutorial-list">
+                <li><span class="key">W / ↑</span> springt · <span class="key">A / ←</span> bewegt nach links · <span class="key">D / →</span> bewegt nach rechts.</li>
+                <li>Springe auf kleinere Bugs oder nutze die <strong>Debug-Kanone</strong> (Taste <span class="key">Leertaste</span>) nachdem du sie freigeschaltet hast.</li>
+                <li>Sammle <strong>Kaffeetassen</strong>, um HP zu regenerieren, und <strong>Code-Snippets</strong> für Punkte.</li>
+                <li>Nach jedem Level wartet ein kurzes <strong>Block-Schiebepuzzle</strong>. Ordne die Karten dem richtigen Slot zu, um Bonus-HP zu kassieren.</li>
+            </ul>
+            <button id="start-button" class="btn btn--primary">Debug-Reise starten</button>
+        </div>
+    </section>
+
+    <section id="game-area" aria-live="polite">
+        <canvas id="game-canvas" width="960" height="576" role="img" aria-label="2D Plattform-Abenteuer"></canvas>
+        <div id="weapon-unlock" class="toast" aria-live="assertive" hidden></div>
+    </section>
+
+    <section id="level-complete" class="overlay" role="dialog" aria-modal="true" hidden>
+        <div class="overlay__content">
+            <h2>Level geschafft!</h2>
+            <p id="level-summary">Du hast alle Bugs in diesem Sprint beseitigt.</p>
+            <button id="puzzle-button" class="btn btn--primary">Zum Bonus-Puzzle</button>
+        </div>
+    </section>
+
+    <section id="puzzle-overlay" class="overlay" role="dialog" aria-modal="true" hidden>
+        <div class="overlay__content overlay__content--wide">
+            <h2>Code-Block Puzzle</h2>
+            <p>Ziehe die Code-Snippets zu den passenden Slots. Schaffst du es, wartet frischer Kaffee (+HP) und ein Score-Bonus.</p>
+            <div class="puzzle">
+                <div class="puzzle__board">
+                    <div class="puzzle-slot" data-accept="api" aria-label="Slot für API"></div>
+                    <div class="puzzle-slot" data-accept="ui" aria-label="Slot für UI"></div>
+                    <div class="puzzle-slot" data-accept="deploy" aria-label="Slot für Deployment"></div>
+                </div>
+                <div class="puzzle__pieces">
+                    <div class="puzzle-piece" draggable="true" data-id="ui">CSS Refactor</div>
+                    <div class="puzzle-piece" draggable="true" data-id="deploy">CI/CD Skript</div>
+                    <div class="puzzle-piece" draggable="true" data-id="api">REST Endpoint</div>
+                </div>
+            </div>
+            <div class="puzzle__actions">
+                <button id="puzzle-reset" class="btn">Neu mischen</button>
+            </div>
+        </div>
+    </section>
+
+    <section id="game-over" class="overlay" role="alertdialog" aria-modal="true" hidden>
+        <div class="overlay__content">
+            <h2>Game Over</h2>
+            <p>Die Bugs waren diesmal schneller. Versuch es direkt noch einmal!</p>
+            <button class="btn btn--primary" data-action="restart">Neu starten</button>
+        </div>
+    </section>
+
+    <section id="victory" class="overlay" role="alertdialog" aria-modal="true" hidden>
+        <div class="overlay__content">
+            <h2>Du hast die Release-Party erreicht!</h2>
+            <p id="victory-summary">Alle drei Level erledigt – der Code ist produktionsreif.</p>
+            <button class="btn btn--primary" data-action="restart">Nochmal spielen</button>
+        </div>
+    </section>
+</main>
+<script src="assets/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the landing-page narrative with a HUD-driven Debug Dash layout including tutorial, game, puzzle, and victory overlays
- restyle the project with neon night visuals for the HUD, canvas frame, toast notifications, and drag-and-drop puzzle slots
- implement a canvas-based 2D platformer with three levels, enemies, collectibles, a weapon unlock, health/score management, and a bonus puzzle reward loop
- refresh the README to document controls, features, and local setup for the new platformer

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68caf5a209608325a59bcf35517e5701